### PR TITLE
Call Single ScanSingleArtifact functions and fix extract images from yaml

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -108,9 +108,9 @@ func getUserInput() string {
 
 func scanSingleArtifact(artifactRef string, saveReport bool, jsonOutput bool) {
 	if isHelmChart(artifactRef) {
-		scanSingleHelmChart(artifactRef, saveReport, jsonOutput)
+		helmscan.ScanSingleHelmChart(artifactRef, saveReport, jsonOutput)
 	} else {
-		scanSingleImage(artifactRef, saveReport, jsonOutput)
+		imageScan.ScanSingleImage(artifactRef, saveReport, jsonOutput)
 	}
 }
 
@@ -142,44 +142,6 @@ func compareArtifacts(ref1, ref2 string, saveReport bool, jsonOutput bool) {
 func isHelmChart(ref string) bool {
 	// This is a simple heuristic. You might want to improve this logic.
 	return strings.Contains(ref, "/") && strings.Contains(ref, "@")
-}
-
-func scanSingleImage(imageURL string, saveReport bool, jsonOutput bool) {
-	logger.Infof("Scanning image: %s", imageURL)
-	result, err := imageScan.ScanImage(imageURL)
-	if err != nil {
-		logger.Errorf("Error scanning image: %v", err)
-		return
-	}
-
-	// Generate and handle the report
-	report := imageScan.GenerateReport(&imageScan.ImageComparisonReport{
-		Image2: result,
-	}, jsonOutput, saveReport)
-
-	// Print to console
-	fmt.Println(report)
-}
-
-func scanSingleHelmChart(chartRef string, saveReport bool, jsonOutput bool) {
-	logger.Infof("Scanning Helm chart: %s", chartRef)
-	parts := strings.Split(chartRef, "@")
-	if len(parts) != 2 {
-		logger.Fatalf("Invalid Helm chart reference. Expected format: repo/chart@version")
-	}
-	result, err := helmscan.Scan(chartRef)
-	if err != nil {
-		logger.Errorf("Error scanning Helm chart: %v", err)
-		return
-	}
-
-	// Generate and handle the report
-	report := helmscan.GenerateReport(helmscan.HelmComparison{
-		After: result,
-	}, jsonOutput, saveReport)
-
-	// Print to console
-	fmt.Println(report)
 }
 
 func compareHelmCharts(chartRef1, chartRef2 string, saveReport bool, jsonOutput bool) {

--- a/internal/helmscan/helmscan.go
+++ b/internal/helmscan/helmscan.go
@@ -263,7 +263,7 @@ func compareImageVulnerabilities(before, after *ContainerImage, comparison *Helm
 
 func extractImagesFromYAML(yamlData []byte) ([]*ContainerImage, error) {
 	// Use yq to convert YAML to JSON, then use jq to extract image values
-	cmd := exec.Command("bash", "-c", `yq e -o json - | jq -r '.. | .image? | select(.)'`)
+	cmd := exec.Command("bash", "-c", `yq '.. | .image? | select(.)'`)
 	cmd.Stdin = bytes.NewReader(yamlData)
 	output, err := cmd.Output()
 	if err != nil {
@@ -284,6 +284,7 @@ func extractImagesFromYAML(yamlData []byte) ([]*ContainerImage, error) {
 }
 
 func parseImageString(imageString string) *ContainerImage {
+	imageString = strings.Trim(imageString, "\"")
 	parts := strings.Split(imageString, ":")
 	var repository, imageName, tag string
 
@@ -637,7 +638,7 @@ func GenerateSingleScanReport(chart HelmChart, jsonOutput bool) string {
 	return reports.GenerateSingleScanReport("helm", chartRef, vulns, jsonOutput)
 }
 
-func scanSingleHelmChart(chartRef string, saveReport bool, jsonOutput bool) {
+func ScanSingleHelmChart(chartRef string, saveReport bool, jsonOutput bool) {
 	logger.Infof("Scanning Helm chart: %s", chartRef)
 	result, err := Scan(chartRef)
 	if err != nil {

--- a/internal/imageScan/imageScan.go
+++ b/internal/imageScan/imageScan.go
@@ -492,7 +492,7 @@ func convertVulnMapToInterface(vulns map[string][]Vulnerability) map[string]map[
 	return result
 }
 
-func scanSingleImage(imageURL string, saveReport bool, jsonOutput bool) {
+func ScanSingleImage(imageURL string, saveReport bool, jsonOutput bool) {
 	logger.Infof("Scanning image: %s", imageURL)
 	result, err := ScanImage(imageURL)
 	if err != nil {


### PR DESCRIPTION
1. Call already present single artifact scan functions
2. Extract images from yaml was not working for me. 
When running 
```sh
./HelmScan --report kubecost/cost-analyzer@2.4.3
```
Got the error 
```sh
2024-12-20T17:34:27.366+0530	ERROR	Error scanning Helm chart: errors occurred during image scanning:
error scanning image : error running command: exit status 1
```
Corrected the cmd to get the images and scan report
```sh
Report saved to: working-files/helm_scan_kubecost_cost-analyzer_2_4_3.md
# Helm Scan Report
## Artifact: kubecost/cost-analyzer@2.4.3
```