### PR TITLE
fix: extracting images from yaml

### DIFF
--- a/internal/helmscan/helmscan.go
+++ b/internal/helmscan/helmscan.go
@@ -210,7 +210,7 @@ func compareImageVulnerabilities(before, after *helmscanTypes.ContainerImage, co
 }
 
 func extractImagesFromYAML(yamlData []byte) ([]*helmscanTypes.ContainerImage, error) {
-	cmd := exec.Command("bash", "-c", `yq e -o json - | jq -r '.. | .image? | select(.)'`)
+	cmd := exec.Command("bash", "-c", `yq '.. | .image? | select(.)'`)
 	cmd.Stdin = bytes.NewReader(yamlData)
 	output, err := cmd.Output()
 	if err != nil {
@@ -221,6 +221,7 @@ func extractImagesFromYAML(yamlData []byte) ([]*helmscanTypes.ContainerImage, er
 
 	var images []*helmscanTypes.ContainerImage
 	for _, imageString := range imageStrings {
+		imageString = strings.Trim(imageString, "\"")
 		image := parseImageString(imageString)
 		images = append(images, image)
 	}


### PR DESCRIPTION
The command is not able to extract the images from the yaml data correctly. Getting the following 
![image](https://github.com/user-attachments/assets/ec13597d-ffa1-4fa8-a518-6f7b388678ec)

Fixed the command to get all the images correctly
![image](https://github.com/user-attachments/assets/61bbbafc-1aaa-4980-8203-42a0beb1372f)
