### PR TITLE
Ensure that we count a CVE only once per image

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ working-files/
     trivy_output/
       {image}_trivy_output.json
 ```
+
+
+## Contributing
+
+### Building
+```bash
+go build -o helmscan cmd/app/main.go
+```
+This will build the binary for the current platform.
+
+Installing Trivy:
+```bash
+brew install aquasecurity/trivy/trivy
+```

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -117,11 +117,8 @@ func scanSingleHelmChart(chartRef string, jsonOutput bool, report bool) {
 		return
 	}
 
-	reportOutput := helmscan.GenerateReport(helmscanTypes.HelmComparison{
-		After: result,
-	}, jsonOutput, report)
-
-	fmt.Println(reportOutput)
+	comparison := helmscan.CompareHelmCharts(helmscanTypes.HelmChart{}, result)
+	helmscan.GenerateReport(comparison, jsonOutput, report)
 }
 
 func compareHelmCharts(chartRef1, chartRef2 string, jsonOutput bool, report bool) {

--- a/internal/helmscan/helmscan.go
+++ b/internal/helmscan/helmscan.go
@@ -159,10 +159,8 @@ func CompareHelmCharts(before, after helmscanTypes.HelmChart) helmscanTypes.Helm
 			for ID, vuln := range beforeImg.Vulnerabilities {
 				if _, exists := comparison.RemovedCVEs[ID]; !exists {
 					comparison.RemovedCVEs[ID] = make(map[string]helmscanTypes.Vulnerability)
-					comparison.RemovedCVEs[ID][name] = vuln
-				} else {
-					comparison.RemovedCVEs[ID][name] = vuln
 				}
+				comparison.RemovedCVEs[ID][name] = vuln
 			}
 		}
 	}
@@ -173,10 +171,8 @@ func CompareHelmCharts(before, after helmscanTypes.HelmChart) helmscanTypes.Helm
 			for ID, vuln := range afterImg.Vulnerabilities {
 				if _, exists := comparison.AddedCVEs[ID]; !exists {
 					comparison.AddedCVEs[ID] = make(map[string]helmscanTypes.Vulnerability)
-					comparison.AddedCVEs[ID][name] = vuln
-				} else {
-					comparison.AddedCVEs[ID][name] = vuln
 				}
+				comparison.AddedCVEs[ID][name] = vuln
 			}
 		}
 	}
@@ -185,26 +181,26 @@ func CompareHelmCharts(before, after helmscanTypes.HelmChart) helmscanTypes.Helm
 }
 
 func compareImageVulnerabilities(before, after *helmscanTypes.ContainerImage, comparison *helmscanTypes.HelmComparison) {
-	for id, vuln := range before.Vulnerabilities {
-		if _, exists := after.Vulnerabilities[id]; !exists {
-			if _, exists := comparison.RemovedCVEs[id]; !exists {
-				comparison.RemovedCVEs[id] = make(map[string]helmscanTypes.Vulnerability)
+	for ID, vuln := range before.Vulnerabilities {
+		if _, exists := after.Vulnerabilities[ID]; !exists {
+			if _, exists := comparison.RemovedCVEs[ID]; !exists {
+				comparison.RemovedCVEs[ID] = make(map[string]helmscanTypes.Vulnerability)
 			}
-			comparison.RemovedCVEs[id][before.ImageName] = vuln
+			comparison.RemovedCVEs[ID][before.ImageName] = vuln
 		} else {
-			if _, exists := comparison.UnchangedCVEs[id]; !exists {
-				comparison.UnchangedCVEs[id] = make(map[string]helmscanTypes.Vulnerability)
+			if _, exists := comparison.UnchangedCVEs[ID]; !exists {
+				comparison.UnchangedCVEs[ID] = make(map[string]helmscanTypes.Vulnerability)
 			}
-			comparison.UnchangedCVEs[id][before.ImageName] = vuln
+			comparison.UnchangedCVEs[ID][before.ImageName] = vuln
 		}
 	}
 
-	for id, vuln := range after.Vulnerabilities {
-		if _, exists := before.Vulnerabilities[id]; !exists {
-			if _, exists := comparison.AddedCVEs[id]; !exists {
-				comparison.AddedCVEs[id] = make(map[string]helmscanTypes.Vulnerability)
+	for ID, vuln := range after.Vulnerabilities {
+		if _, exists := before.Vulnerabilities[ID]; !exists {
+			if _, exists := comparison.AddedCVEs[ID]; !exists {
+				comparison.AddedCVEs[ID] = make(map[string]helmscanTypes.Vulnerability)
 			}
-			comparison.AddedCVEs[id][after.ImageName] = vuln
+			comparison.AddedCVEs[ID][after.ImageName] = vuln
 		}
 	}
 }

--- a/internal/helmscan/helmscan.go
+++ b/internal/helmscan/helmscan.go
@@ -214,11 +214,19 @@ func extractImagesFromYAML(yamlData []byte) ([]*helmscanTypes.ContainerImage, er
 	}
 
 	imageStrings := strings.Split(strings.TrimSpace(string(output)), "\n")
-
 	var images []*helmscanTypes.ContainerImage
+	m := map[string]bool{} // map to filter out duplicate images
 	for _, imageString := range imageStrings {
 		imageString = strings.Trim(imageString, "\"")
+		// Filter out YAML document separators
+		if imageString == "---" {
+			continue
+		}
 		image := parseImageString(imageString)
+		if _, exists := m[imageString]; exists {
+			continue
+		}
+		m[imageString] = true
 		images = append(images, image)
 	}
 

--- a/internal/imageScan/imageScan.go
+++ b/internal/imageScan/imageScan.go
@@ -110,16 +110,16 @@ func CompareScans(firstScan, secondScan helmscanTypes.ScanResult) *helmscanTypes
 		secondVulns[vuln.ID] = vuln
 	}
 
-	for id, vuln := range firstVulns {
-		if _, exists := secondVulns[id]; exists {
+	for ID, vuln := range firstVulns {
+		if _, exists := secondVulns[ID]; exists {
 			comparison.UnchangedCVEs[vuln.Severity] = append(comparison.UnchangedCVEs[vuln.Severity], vuln)
 		} else {
 			comparison.RemovedCVEs[vuln.Severity] = append(comparison.RemovedCVEs[vuln.Severity], vuln)
 		}
 	}
 
-	for id, vuln := range secondVulns {
-		if _, exists := firstVulns[id]; !exists {
+	for ID, vuln := range secondVulns {
+		if _, exists := firstVulns[ID]; !exists {
 			comparison.AddedCVEs[vuln.Severity] = append(comparison.AddedCVEs[vuln.Severity], vuln)
 		}
 	}

--- a/internal/imageScan/imageScan.go
+++ b/internal/imageScan/imageScan.go
@@ -34,10 +34,6 @@ func init() {
 }
 
 func ScanImage(imageName string) (helmscanTypes.ScanResult, error) {
-	if strings.Contains(imageName, "alpine") {
-		return helmscanTypes.ScanResult{}, nil
-	}
-
 	if err := os.MkdirAll("working-files/tmp/trivy_output", 0755); err != nil {
 		return helmscanTypes.ScanResult{}, fmt.Errorf("failed to create working directory: %w", err)
 	}

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -383,10 +383,12 @@ func GenerateJSONSeverityCounts(comparison helmscanTypes.HelmComparison) []Sever
 	afterImages := make(map[string]*helmscanTypes.ContainerImage)
 
 	for _, img := range comparison.Before.ContainsImages {
-		beforeImages[img.ImageName] = img
+		fullImageName := fmt.Sprintf("%s/%s:%s", img.Repository, img.ImageName, img.Tag)
+		beforeImages[fullImageName] = img
 	}
 	for _, img := range comparison.After.ContainsImages {
-		afterImages[img.ImageName] = img
+		fullImageName := fmt.Sprintf("%s/%s:%s", img.Repository, img.ImageName, img.Tag)
+		afterImages[fullImageName] = img
 	}
 
 	prevCounts := make(map[string]int)

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -378,27 +378,14 @@ func GenerateJSONSeverityCounts(comparison helmscanTypes.HelmComparison) []Sever
 	severities := []string{"critical", "high", "medium", "low"}
 	counts := make([]SeverityCount, 0, len(severities))
 
-	// Ensure each CVE is counted only once per image, as duplicate images may exist in the helm chart comparison
-	beforeImages := make(map[string]*helmscanTypes.ContainerImage)
-	afterImages := make(map[string]*helmscanTypes.ContainerImage)
-
-	for _, img := range comparison.Before.ContainsImages {
-		fullImageName := fmt.Sprintf("%s/%s:%s", img.Repository, img.ImageName, img.Tag)
-		beforeImages[fullImageName] = img
-	}
-	for _, img := range comparison.After.ContainsImages {
-		fullImageName := fmt.Sprintf("%s/%s:%s", img.Repository, img.ImageName, img.Tag)
-		afterImages[fullImageName] = img
-	}
-
 	prevCounts := make(map[string]int)
 	currentCounts := make(map[string]int)
-	for _, img := range beforeImages {
+	for _, img := range comparison.Before.ContainsImages {
 		for _, vuln := range img.Vulnerabilities {
 			prevCounts[vuln.Severity]++
 		}
 	}
-	for _, img := range afterImages {
+	for _, img := range comparison.After.ContainsImages {
 		for _, vuln := range img.Vulnerabilities {
 			currentCounts[vuln.Severity]++
 		}


### PR DESCRIPTION
During helm chart scan duplicate images can be present. This could lead to counting the same CVE for the same image multiple times. The change intends to first filter out unique images and then count the CVEs in them.

Filter out file separator when getting images

Add back scanning of alpine images

Also added few code consistency changes